### PR TITLE
feat: Add Jupyter Pytorch CUDA Compiler Image

### DIFF
--- a/.github/workflows/kfnb-jupyter-pytorch-cuda-compiler.yml
+++ b/.github/workflows/kfnb-jupyter-pytorch-cuda-compiler.yml
@@ -1,0 +1,74 @@
+name: Publish Kubeflow Notebook Jupyter Pytorch Cuda Compiler Image
+
+on:
+  workflow_dispatch: # Allows to trigger the workflow manually in GitHub UI
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/kubeflow-notebooks/jupyter-pytorch-cuda-compiler
+  BASE_IMAGE: ${{ github.repository_owner }}/kubeflow-notebooks/jupyter-pytorch-cuda:1d4424a
+  CACHE_IMAGE: ${{ github.repository_owner }}/kubeflow-notebooks/build-cache
+  CACHE_TAG: jupyter-pytorch-cuda-compiler
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      # `docker/metadata-action` does this for us, but the `cache-from` and `cache-to` inputs directly read env and are cursed.
+      # See this long discussion: <https://github.com/orgs/community/discussions/25768>
+      - id: lower-repo
+        run: |
+          echo "CACHE_IMAGE=${CACHE_IMAGE@L}" >> ${GITHUB_ENV}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.6.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # semver has default priority 900, sha has default priority 100
+          # ref has default priority 600
+          # see <https://github.com/docker/metadata-action#priority-attribute>
+          # also, sha has a default prefix of '-sha'
+          # see <https://github.com/docker/metadata-action#typesha>
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,priority=850,prefix=
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6.13.0
+        with:
+          file: kubeflow/notebook-servers/jupyter-pytorch-cuda-compiler/Dockerfile
+          context: kubeflow/notebook-servers/jupyter-pytorch-cuda-compiler
+          # The index (https://download.pytorch.org/whl/cu121) is hard-coded in the Dockerfile,
+          # which only supports up to these versions.
+          build-args: |
+            BASE_IMG=${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}
+            CUDA_VERSION=12.1.1
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.CACHE_IMAGE }}:${{ env.CACHE_TAG }}
+          # See <https://docs.docker.com/build/cache/backends/#cache-mode>
+          cache-to: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.CACHE_IMAGE }}:${{ env.CACHE_TAG }},mode=max
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/kubeflow/notebook-servers/jupyter-pytorch-cuda-compiler/Dockerfile
+++ b/kubeflow/notebook-servers/jupyter-pytorch-cuda-compiler/Dockerfile
@@ -1,0 +1,8 @@
+ARG BASE_IMG=<base>
+FROM $BASE_IMG
+
+ARG CUDA_VERSION=12.1.1
+
+# We still need to specify the channel. for all the dependencies.
+# See <https://stackoverflow.com/a/78843983/6564721>
+RUN conda install nvidia/label/cuda-${CUDA_VERSION}::cuda-compiler -c nvidia/label/cuda-${CUDA_VERSION} -y


### PR DESCRIPTION
Some libraries, such as DeepSpeed, require cuda to be installed. Pytorch ships with its own cuda runtime, but without the CUDA toolkit, installing these libraries on Kubeflow's PyTorch images can be challenging. This update addresses that issue by providing a Jupyter image with the necessary CUDA compiler support.