### PR TITLE
chore: upgrade codeserver python's deps

### DIFF
--- a/.github/workflows/kfnb-codeserver-python.yml
+++ b/.github/workflows/kfnb-codeserver-python.yml
@@ -6,7 +6,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/kubeflow-notebooks/codeserver-python
-  BASE_IMAGE: ${{ github.repository_owner }}/kubeflow-notebooks/codeserver:2ec3ca1
+  BASE_IMAGE: ${{ github.repository_owner }}/kubeflow-notebooks/codeserver:cce3c74
   CACHE_IMAGE: ${{ github.repository_owner }}/kubeflow-notebooks/build-cache
   CACHE_TAG: codeserver-python
 
@@ -70,10 +70,10 @@ jobs:
           build-args: |
             BASE_IMG=${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}
             CODESERVER_PYTHON_VERSION=2025.4.0
-            CODESERVER_JUPYTER_VERSION=2025.6.0
-            IPYKERNEL_VERSION=6.29.5
-            MINIFORGE_VERSION=25.3.0-3
-            PIP_VERSION=25.1.1
+            CODESERVER_JUPYTER_VERSION=2025.7.0
+            IPYKERNEL_VERSION=6.30.1
+            MINIFORGE_VERSION=25.3.1-0
+            PIP_VERSION=25.2
             PYTHON_VERSION=3.13.5
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.CACHE_IMAGE }}:${{ env.CACHE_TAG }}


### PR DESCRIPTION
Do not merge. Python 3.13.7 is not in the conda forge channel yet.